### PR TITLE
update Say emote to have default Extent of 0 instead of 1 (default chat broadcast range)

### DIFF
--- a/EmoteScriptLib/Converter.cs
+++ b/EmoteScriptLib/Converter.cs
@@ -260,6 +260,7 @@ namespace EmoteScriptLib
 
             var indent = string.Concat(Enumerable.Repeat("    ", depth));
 
+            // TODO: detect when fields are used outside of fluent syntax, and fallback on kvp syntax
             scriptLines.Add($"{indent}- {emote.ToString(true)}");
 
             if (emote.Branches != null)

--- a/EmoteScriptLib/JSON/Emote.cs
+++ b/EmoteScriptLib/JSON/Emote.cs
@@ -40,7 +40,7 @@ namespace EmoteScriptLib.JSON
         {
             type = (uint)emote.Type;
             delay = emote.Delay ?? 0.0f;
-            extent = emote.Extent ?? 1.0f;
+            extent = emote.Extent ?? (emote.Type == Entity.Enum.EmoteType.Say ? 0.0f : 1.0f);
             amount = (uint?)emote.Amount;
             motion = (uint?)emote.Motion;
             msg = emote.Message;

--- a/EmoteScriptLib/SQL/SQLReader.cs
+++ b/EmoteScriptLib/SQL/SQLReader.cs
@@ -135,7 +135,20 @@ namespace EmoteScriptLib.SQL
                 }
                 var value = GetValueType(prop, fields[i]);
 
-                if (DefaultValues.TryGetValue(propName, out var defaultValue) && value.ToString().Equals(defaultValue))
+                // special handling for default extent based on emote type
+                if (propName.Equals("Extent"))
+                {
+                    var defaultExtent = "1";
+
+                    var typeIdx = currentColumns.IndexOf("type");
+
+                    if (typeIdx != -1 && fields[typeIdx] == "8")  // EmoteType.Say
+                        defaultExtent = "0";
+
+                    if (value.ToString().Equals(defaultExtent))
+                        continue;
+                }
+                else if (DefaultValues.TryGetValue(propName, out var defaultValue) && value.ToString().Equals(defaultValue))
                     continue;
 
                 prop.SetValue(record, value, null);

--- a/EmoteScriptLib/SQL/SQLWriter.cs
+++ b/EmoteScriptLib/SQL/SQLWriter.cs
@@ -58,7 +58,7 @@ namespace EmoteScriptLib.SQL
 
                 var typeStr = $"{(int)emote.Type} /* {emote.Type} */";
                 var delay = emote.Delay?.ToString() ?? "0";
-                var extent = emote.Extent?.ToString() ?? "1";
+                var extent = emote.Extent?.ToString() ?? (emote.Type == EmoteType.Say ? "0" : "1");
                 var motionStr = emote.Motion != null ? $"0x{(uint)emote.Motion:X8} /* {emote.Motion} */" : "NULL";
                 var message = GetSQLString(emote.Message);
                 var testString = GetSQLString(emote.TestString);


### PR DESCRIPTION
This resolves some issues with https://github.com/gmriggs/EmoteScript/issues/7